### PR TITLE
style: Replace Bootstrap Fade component with custom Emotion Fade component

### DIFF
--- a/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
+++ b/superset-frontend/spec/javascripts/sqllab/TableElement_spec.jsx
@@ -23,6 +23,7 @@ import configureStore from 'redux-mock-store';
 import { supersetTheme, ThemeProvider } from '@superset-ui/core';
 
 import Link from 'src/components/Link';
+import Fade from 'src/common/components/Fade';
 import TableElement from 'src/SqlLab/components/TableElement';
 import ColumnElement from 'src/SqlLab/components/ColumnElement';
 
@@ -62,6 +63,14 @@ describe('TableElement', () => {
         },
       },
     );
+  });
+  it('fades table', () => {
+    const wrapper = shallow(<TableElement {...mockedProps} />)
+    expect(wrapper.state().hovered).toBe(false);
+    expect(wrapper.find(Fade).props().hovered).toBe(false);
+    wrapper.find('div.TableElement').simulate('mouseEnter');
+    expect(wrapper.state().hovered).toBe(true);
+    expect(wrapper.find(Fade).props().hovered).toBe(true);
   });
   it('sorts columns', () => {
     const wrapper = shallow(<TableElement {...mockedProps} />);

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -22,13 +22,13 @@ import { ButtonGroup, Collapse, Well } from 'react-bootstrap';
 import shortid from 'shortid';
 import { t } from '@superset-ui/core';
 
+import Fade from 'src/common/components/Fade';
 import CopyToClipboard from '../../components/CopyToClipboard';
 import Link from '../../components/Link';
 import ColumnElement from './ColumnElement';
 import ShowSQL from './ShowSQL';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
-import Fade from 'src/common/components/Fade';
 
 const propTypes = {
   table: PropTypes.object,

--- a/superset-frontend/src/SqlLab/components/TableElement.jsx
+++ b/superset-frontend/src/SqlLab/components/TableElement.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ButtonGroup, Collapse, Fade, Well } from 'react-bootstrap';
+import { ButtonGroup, Collapse, Well } from 'react-bootstrap';
 import shortid from 'shortid';
 import { t } from '@superset-ui/core';
 
@@ -28,6 +28,7 @@ import ColumnElement from './ColumnElement';
 import ShowSQL from './ShowSQL';
 import ModalTrigger from '../../components/ModalTrigger';
 import Loading from '../../components/Loading';
+import Fade from 'src/common/components/Fade';
 
 const propTypes = {
   table: PropTypes.object,
@@ -215,7 +216,7 @@ class TableElement extends React.PureComponent {
           {table.isMetadataLoading || table.isExtraMetadataLoading ? (
             <Loading position="inline" />
           ) : (
-            <Fade in={this.state.hovered}>{this.renderControls()}</Fade>
+            <Fade hovered={this.state.hovered}>{this.renderControls()}</Fade>
           )}
           <i
             role="button"

--- a/superset-frontend/src/common/components/Fade.tsx
+++ b/superset-frontend/src/common/components/Fade.tsx
@@ -1,10 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 import { styled } from '@superset-ui/core';
 
 type FadeProps = { hovered: boolean };
 
 const Fade = styled.div<FadeProps>`
     transition: all ${({ theme }) => theme.transitionTiming}s;
-    opacity: ${props => props.hovered ? 1 : 0};
+    opacity: ${props => (props.hovered ? 1 : 0)};
 `
 
 export default Fade;

--- a/superset-frontend/src/common/components/Fade.tsx
+++ b/superset-frontend/src/common/components/Fade.tsx
@@ -1,0 +1,10 @@
+import { styled } from '@superset-ui/core';
+
+type FadeProps = { hovered: boolean };
+
+const Fade = styled.div<FadeProps>`
+    transition: all ${({ theme }) => theme.transitionTiming}s;
+    opacity: ${props => props.hovered ? 1 : 0};
+`
+
+export default Fade;


### PR DESCRIPTION
### SUMMARY
Replacing Bootstrap <Fade> component with custom Emotion/CSS component with same behaviour in effort to move away from Bootstrap.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before: https://www.loom.com/share/e1ba9e7671c34581858043bfca669ea1
After: https://www.loom.com/share/7228d0769f3247bba5aedec407d7f3bc

### TEST PLAN
1. Log into Superset
2. Navigate to **SQL Lab > SQL Editor** (<host>/superset/sqllab)
3. Query a table
4. Hover over Table Element on the left side of the screen

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
