### PR TITLE
chore: Hide filter bar for no filters & show edit button to owners only

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -150,6 +150,9 @@ class DashboardBuilder extends React.Component {
 
     this.handleChangeTab = this.handleChangeTab.bind(this);
     this.handleDeleteTopLevelTabs = this.handleDeleteTopLevelTabs.bind(this);
+    this.toggleDashboardFiltersOpen = this.toggleDashboardFiltersOpen.bind(
+      this,
+    );
   }
 
   getChildContext() {
@@ -176,10 +179,19 @@ class DashboardBuilder extends React.Component {
     }
   }
 
-  toggleDashboardFiltersOpen = () => {
-    const nextState = !this.state.dashboardFiltersOpen;
-    this.setState(state => ({ ...state, dashboardFiltersOpen: nextState }));
-  };
+  toggleDashboardFiltersOpen(visible) {
+    if (visible === undefined) {
+      this.setState(state => ({
+        ...state,
+        dashboardFiltersOpen: !state.dashboardFiltersOpen,
+      }));
+    } else {
+      this.setState(state => ({
+        ...state,
+        dashboardFiltersOpen: visible,
+      }));
+    }
+  }
 
   handleChangeTab({ pathToTabIndex }) {
     this.props.setDirectPathToChild(pathToTabIndex);

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -236,7 +236,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
 
   useEffect(() => {
     if (filterConfigs.length === 0 && filtersOpen) {
-      toggleFiltersBar();
+      toggleFiltersBar(false);
     }
   }, [filterConfigs]);
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -18,6 +18,7 @@
  */
 import { QueryFormData, styled, SuperChart, t } from '@superset-ui/core';
 import React, { useState, useEffect } from 'react';
+import { useSelector } from 'react-redux';
 import cx from 'classnames';
 import { Form } from 'src/common/components';
 import Button from 'src/components/Button';
@@ -229,6 +230,9 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   toggleFiltersBar,
 }) => {
   const filterConfigs = useFilterConfiguration();
+  const canEdit = useSelector<any, boolean>(
+    ({ dashboardInfo }) => dashboardInfo.dash_edit_perm,
+  );
 
   useEffect(() => {
     if (filterConfigs.length === 0 && filtersOpen) {
@@ -250,9 +254,11 @@ const FilterBar: React.FC<FiltersBarProps> = ({
           <span>
             {t('Filters')} ({filterConfigs.length})
           </span>
-          <FilterConfigurationLink>
-            <Icon name="edit" data-test="create-filter" />
-          </FilterConfigurationLink>
+          {canEdit && (
+            <FilterConfigurationLink>
+              <Icon name="edit" data-test="create-filter" />
+            </FilterConfigurationLink>
+          )}
           <Icon name="expand" onClick={toggleFiltersBar} />
         </TitleArea>
         <ActionButtons>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -230,6 +230,12 @@ const FilterBar: React.FC<FiltersBarProps> = ({
 }) => {
   const filterConfigs = useFilterConfiguration();
 
+  useEffect(() => {
+    if (filterConfigs.length === 0 && filtersOpen) {
+      toggleFiltersBar();
+    }
+  }, [filterConfigs]);
+
   return (
     <BarWrapper data-test="filter-bar" className={cx({ open: filtersOpen })}>
       <CollapsedBar


### PR DESCRIPTION
### SUMMARY
Following changes were applied to the Filter Bar:
- Hide Filter bar where there are no filters
- Show edit button for dashboard owners only 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Hide Filter bar where there are no filters**
**before:**
![0filters_before](https://user-images.githubusercontent.com/47450693/101177750-74335b00-3648-11eb-841a-8e9ab51d6c3f.gif)

**after:**
![filters0_after](https://user-images.githubusercontent.com/47450693/101177771-7990a580-3648-11eb-8acb-bb9801ebcd7b.gif)

**Show edit button for dashboard owners only**
**before:**
<img width="1780" alt="edit_button_before" src="https://user-images.githubusercontent.com/47450693/101176841-5c0f0c00-3647-11eb-9e79-c94b384cad7e.png">

**after:**
![image](https://user-images.githubusercontent.com/47450693/101176619-089cbe00-3647-11eb-9394-f677463a7825.png)

### TEST PLAN
Verify manually:
Open Dashboard with no filters applied
You should see filter bar hidden at the beginning

Open Dashboard in which you not the owner (and you are not admin)
You should not see edit icon in the Filter bar

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @villebro @suddjian 