### PR TITLE
feature: Enable applying changes by clicking Apply button

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -16,7 +16,13 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { QueryFormData, styled, SuperChart, t } from '@superset-ui/core';
+import {
+  QueryFormData,
+  styled,
+  SuperChart,
+  t,
+  ExtraFormData,
+} from '@superset-ui/core';
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import cx from 'classnames';
@@ -145,7 +151,7 @@ const FilterControls = styled.div`
 
 interface FilterProps {
   filter: Filter;
-  onExtraFormDataChange: any;
+  onExtraFormDataChange: (filter: Filter, extraFormData: ExtraFormData) => void;
 }
 
 interface FiltersBarProps {
@@ -198,7 +204,7 @@ const FilterValue: React.FC<FilterProps> = ({
     }
   }, [cascadingFilters]);
 
-  const setExtraFormData = (extraFormData: any) =>
+  const setExtraFormData = (extraFormData: ExtraFormData) =>
     onExtraFormDataChange(filter, extraFormData);
 
   return (
@@ -241,8 +247,9 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   filtersOpen,
   toggleFiltersBar,
 }) => {
-  const [filterData, setFilterData] = useState({});
-
+  const [filterData, setFilterData] = useState<{ [id: string]: ExtraFormData }>(
+    {},
+  );
   const setExtraFormData = useSetExtraFormData();
   const filterConfigs = useFilterConfiguration();
   const canEdit = useSelector<any, boolean>(
@@ -255,7 +262,10 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     }
   }, [filterConfigs]);
 
-  const handleExtraFormDataChange = (filter: Filter, extraFormData: any) => {
+  const handleExtraFormDataChange = (
+    filter: Filter,
+    extraFormData: ExtraFormData,
+  ) => {
     setFilterData(prevFilterData => ({
       ...prevFilterData,
       [filter.id]: extraFormData,

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -242,6 +242,8 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   filtersOpen,
   toggleFiltersBar,
 }) => {
+  const [filterData, setFilterData] = useState({});
+
   const setExtraFormData = useSetExtraFormData();
   const filterConfigs = useFilterConfiguration();
   const canEdit = useSelector<any, boolean>(
@@ -255,8 +257,17 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   }, [filterConfigs]);
 
   const handleExtraFormDataChange = (filterId: string, extraFormData: any) => {
-    console.log('Extra form data', filterId, extraFormData);
-    setExtraFormData(filterId, extraFormData);
+    setFilterData(prevFilterData => ({
+      ...prevFilterData,
+      [filterId]: extraFormData,
+    }));
+  };
+
+  const handleApply = () => {
+    const filterIds = Object.keys(filterData);
+    filterIds.forEach(filterId => {
+      setExtraFormData(filterId, filterData[filterId]);
+    });
   };
 
   return (
@@ -281,7 +292,12 @@ const FilterBar: React.FC<FiltersBarProps> = ({
           <Icon name="expand" onClick={toggleFiltersBar} />
         </TitleArea>
         <ActionButtons>
-          <Button buttonStyle="primary" type="submit" buttonSize="sm">
+          <Button
+            buttonStyle="primary"
+            type="submit"
+            buttonSize="sm"
+            onClick={handleApply}
+          >
             {t('Apply')}
           </Button>
           <Button buttonStyle="secondary" buttonSize="sm">

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -158,7 +158,6 @@ const FilterValue: React.FC<FilterProps> = ({
   onExtraFormDataChange,
 }) => {
   const { id } = filter;
-  // const setExtraFormData = useSetExtraFormData(id);
   const cascadingFilters = useCascadingFilters(id);
   const [state, setState] = useState({ data: undefined });
   const [formData, setFormData] = useState<Partial<QueryFormData>>({});
@@ -200,7 +199,7 @@ const FilterValue: React.FC<FilterProps> = ({
   }, [cascadingFilters]);
 
   const setExtraFormData = (extraFormData: any) =>
-    onExtraFormDataChange(filter.id, extraFormData);
+    onExtraFormDataChange(filter, extraFormData);
 
   return (
     <Form
@@ -256,17 +255,23 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     }
   }, [filterConfigs]);
 
-  const handleExtraFormDataChange = (filterId: string, extraFormData: any) => {
+  const handleExtraFormDataChange = (filter: Filter, extraFormData: any) => {
     setFilterData(prevFilterData => ({
       ...prevFilterData,
-      [filterId]: extraFormData,
+      [filter.id]: extraFormData,
     }));
+
+    if (filter.isInstant) {
+      setExtraFormData(filter.id, extraFormData);
+    }
   };
 
   const handleApply = () => {
     const filterIds = Object.keys(filterData);
     filterIds.forEach(filterId => {
-      setExtraFormData(filterId, filterData[filterId]);
+      if (filterData[filterId]) {
+        setExtraFormData(filterId, filterData[filterId]);
+      }
     });
   };
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -145,6 +145,7 @@ const FilterControls = styled.div`
 
 interface FilterProps {
   filter: Filter;
+  onExtraFormDataChange: any;
 }
 
 interface FiltersBarProps {
@@ -152,9 +153,12 @@ interface FiltersBarProps {
   toggleFiltersBar: any;
 }
 
-const FilterValue: React.FC<FilterProps> = ({ filter }) => {
+const FilterValue: React.FC<FilterProps> = ({
+  filter,
+  onExtraFormDataChange,
+}) => {
   const { id } = filter;
-  const setExtraFormData = useSetExtraFormData(id);
+  // const setExtraFormData = useSetExtraFormData(id);
   const cascadingFilters = useCascadingFilters(id);
   const [state, setState] = useState({ data: undefined });
   const [formData, setFormData] = useState<Partial<QueryFormData>>({});
@@ -195,6 +199,9 @@ const FilterValue: React.FC<FilterProps> = ({ filter }) => {
     }
   }, [cascadingFilters]);
 
+  const setExtraFormData = (extraFormData: any) =>
+    onExtraFormDataChange(filter.id, extraFormData);
+
   return (
     <Form
       onFinish={values => {
@@ -215,12 +222,18 @@ const FilterValue: React.FC<FilterProps> = ({ filter }) => {
   );
 };
 
-const FilterControl: React.FC<FilterProps> = ({ filter }) => {
+const FilterControl: React.FC<FilterProps> = ({
+  filter,
+  onExtraFormDataChange,
+}) => {
   const { name = '<undefined>' } = filter;
   return (
     <div>
       <h3>{name}</h3>
-      <FilterValue filter={filter} />
+      <FilterValue
+        filter={filter}
+        onExtraFormDataChange={onExtraFormDataChange}
+      />
     </div>
   );
 };
@@ -229,6 +242,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   filtersOpen,
   toggleFiltersBar,
 }) => {
+  const setExtraFormData = useSetExtraFormData();
   const filterConfigs = useFilterConfiguration();
   const canEdit = useSelector<any, boolean>(
     ({ dashboardInfo }) => dashboardInfo.dash_edit_perm,
@@ -239,6 +253,11 @@ const FilterBar: React.FC<FiltersBarProps> = ({
       toggleFiltersBar(false);
     }
   }, [filterConfigs]);
+
+  const handleExtraFormDataChange = (filterId: string, extraFormData: any) => {
+    console.log('Extra form data', filterId, extraFormData);
+    setExtraFormData(filterId, extraFormData);
+  };
 
   return (
     <BarWrapper data-test="filter-bar" className={cx({ open: filtersOpen })}>
@@ -275,6 +294,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
               data-test="filters-control"
               key={filter.id}
               filter={filter}
+              onExtraFormDataChange={handleExtraFormDataChange}
             />
           ))}
         </FilterControls>

--- a/superset-frontend/src/dashboard/components/nativeFilters/state.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/state.ts
@@ -67,12 +67,12 @@ export function useFilterState(id: string) {
   });
 }
 
-export function useSetExtraFormData(id: string) {
+export function useSetExtraFormData() {
   const dispatch = useDispatch();
   return useCallback(
-    (extraFormData: ExtraFormData) =>
+    (id: string, extraFormData: ExtraFormData) =>
       dispatch(setExtraFormData(id, extraFormData)),
-    [id, dispatch],
+    [dispatch],
   );
 }
 


### PR DESCRIPTION
### SUMMARY
The aim of this PR was to make Apply button work. The button is located at the top of the Filter Bar, but it does not lead to any action - right now filters are always applied instantly on the dashboard. In my PR it is possible to click "Apply" if you want your changes to apply after clicking instead of instantly. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![apply_button_before](https://user-images.githubusercontent.com/47450693/101371463-118dc980-38ab-11eb-98a2-d3c4b5ffb6fa.gif)

After:
![apply_button_after](https://user-images.githubusercontent.com/47450693/101371480-19e60480-38ab-11eb-8d51-76efa22b5a93.gif)


### TEST PLAN
Verify manually.
Go to the dashboard
Choose the filter - choose the one without checkbox "Apply changes instantly" checked in your Filter Config Modal
Choose the value from your Filter Control and click "Apply"

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

cc @villebro