### PR TITLE
chore: Add Error Boundary component to Filter bar and Filter Config Modal

### DIFF
--- a/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
+++ b/superset-frontend/src/dashboard/components/DashboardBuilder.jsx
@@ -27,6 +27,7 @@ import { Sticky, StickyContainer } from 'react-sticky';
 import { TabContainer, TabContent, TabPane } from 'react-bootstrap';
 import { styled } from '@superset-ui/core';
 
+import ErrorBoundary from 'src/components/ErrorBoundary';
 import BuilderComponentPane from 'src/dashboard/components/BuilderComponentPane';
 import DashboardHeader from 'src/dashboard/containers/DashboardHeader';
 import DashboardGrid from 'src/dashboard/containers/DashboardGrid';
@@ -284,10 +285,12 @@ class DashboardBuilder extends React.Component {
               filtersOpen={this.state.dashboardFiltersOpen}
               topOffset={barTopOffset}
             >
-              <FilterBar
-                filtersOpen={this.state.dashboardFiltersOpen}
-                toggleFiltersBar={this.toggleDashboardFiltersOpen}
-              />
+              <ErrorBoundary>
+                <FilterBar
+                  filtersOpen={this.state.dashboardFiltersOpen}
+                  toggleFiltersBar={this.toggleDashboardFiltersOpen}
+                />
+              </ErrorBoundary>
             </StickyVerticalBar>
             // <FilterBar />
           )}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -26,6 +26,7 @@ import { StyledModal } from 'src/common/components/Modal';
 import { LineEditableTabs } from 'src/common/components/Tabs';
 import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
 import { usePrevious } from 'src/common/hooks/usePrevious';
+import ErrorBoundary from 'src/components/ErrorBoundary';
 import { useFilterConfigMap, useFilterConfiguration } from './state';
 import FilterConfigForm from './FilterConfigForm';
 import { FilterConfiguration, NativeFiltersForm } from './types';
@@ -230,50 +231,52 @@ export function FilterConfigModal({
       centered
       data-test="filter-modal"
     >
-      <StyledModalBody>
-        <Form
-          form={form}
-          onValuesChange={(changes, values) => {
-            if (
-              changes.filters &&
-              Object.values(changes.filters).some(
-                (filter: any) => filter.name != null,
-              )
-            ) {
-              // we only need to set this if a name changed
-              setFormValues(values);
-            }
-          }}
-        >
-          <LineEditableTabs
-            tabPosition="left"
-            onChange={setCurrentFilterId}
-            activeKey={currentFilterId}
-            onEdit={onTabEdit}
+      <ErrorBoundary>
+        <StyledModalBody>
+          <Form
+            form={form}
+            onValuesChange={(changes, values) => {
+              if (
+                changes.filters &&
+                Object.values(changes.filters).some(
+                  (filter: any) => filter.name != null,
+                )
+              ) {
+                // we only need to set this if a name changed
+                setFormValues(values);
+              }
+            }}
           >
-            {filterIds.map(id => (
-              <LineEditableTabs.TabPane
-                tab={
-                  <RemovedStatus
-                    className={removedFilters[id] ? 'removed' : ''}
-                  >
-                    {getFilterTitle(id)}
-                  </RemovedStatus>
-                }
-                key={id}
-                closeIcon={<DeleteFilled />}
-              >
-                <FilterConfigForm
-                  form={form}
-                  filterId={id}
-                  filterToEdit={filterConfigMap[id]}
-                  removed={!!removedFilters[id]}
-                />
-              </LineEditableTabs.TabPane>
-            ))}
-          </LineEditableTabs>
-        </Form>
-      </StyledModalBody>
+            <LineEditableTabs
+              tabPosition="left"
+              onChange={setCurrentFilterId}
+              activeKey={currentFilterId}
+              onEdit={onTabEdit}
+            >
+              {filterIds.map(id => (
+                <LineEditableTabs.TabPane
+                  tab={
+                    <RemovedStatus
+                      className={removedFilters[id] ? 'removed' : ''}
+                    >
+                      {getFilterTitle(id)}
+                    </RemovedStatus>
+                  }
+                  key={id}
+                  closeIcon={<DeleteFilled />}
+                >
+                  <FilterConfigForm
+                    form={form}
+                    filterId={id}
+                    filterToEdit={filterConfigMap[id]}
+                    removed={!!removedFilters[id]}
+                  />
+                </LineEditableTabs.TabPane>
+              ))}
+            </LineEditableTabs>
+          </Form>
+        </StyledModalBody>
+      </ErrorBoundary>
     </StyledModal>
   );
 }


### PR DESCRIPTION
### SUMMARY
Add Error boundaries to Filter bar and Filter Config Modal. 

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
blank page
<img width="600" alt="blankapge" src="https://user-images.githubusercontent.com/47450693/101482001-4acf4380-3956-11eb-8eca-32e2345f9c41.png">

After:
<img width="600" alt="error_boundary1" src="https://user-images.githubusercontent.com/47450693/101481251-29ba2300-3955-11eb-9400-14935c806414.png">
<img width="530" alt="errorboundary_2" src="https://user-images.githubusercontent.com/47450693/101481305-3dfe2000-3955-11eb-8792-3767031e9613.png">


### TEST PLAN
Verify manually. 
Throw errors: 
for Filter Config Modal, type `throw new Error("test")` i.e. in `FilterConfigForm.tsx` 96 line
for Filter Bar,  type `throw new Error("test")` i.e. in `FilterBar.tsx` 243 line

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @villebro 

