### PR TITLE
feature: Cascading filters Popover

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React from 'react';
+import React, { useCallback } from 'react';
 import { ExtraFormData } from '@superset-ui/core';
 import Popover from 'src/common/components/Popover';
 import Button from 'src/components/Button';
@@ -41,6 +41,28 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
   onVisibleChange,
   onExtraFormDataChange,
 }) => {
+  const getActiveChildren = useCallback(
+    (filter: CascadeFilter): CascadeFilter[] | null => {
+      const children = filter.cascadeChildren || [];
+      const currentValue = filter.currentValue || [];
+
+      const activeChildren = children.flatMap(
+        childFilter => getActiveChildren(childFilter) || [],
+      );
+
+      if (activeChildren.length > 0) {
+        return activeChildren;
+      }
+
+      if (currentValue.length > 0) {
+        return [filter];
+      }
+
+      return null;
+    },
+    [filter],
+  );
+
   const title = <span>Select Parent Filters (ilosc poziomow) {filter.id}</span>;
 
   const content = (
@@ -51,6 +73,8 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
       onExtraFormDataChange={onExtraFormDataChange}
     />
   );
+
+  const activeFilters = getActiveChildren(filter) || [filter];
 
   return (
     <>
@@ -72,10 +96,14 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
           />
         </>
       )}
-      <FilterControl
-        filter={filter}
-        onExtraFormDataChange={onExtraFormDataChange}
-      />
+
+      {activeFilters.map(activeFilter => (
+        <FilterControl
+          key={activeFilter.id}
+          filter={activeFilter}
+          onExtraFormDataChange={onExtraFormDataChange}
+        />
+      ))}
     </>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React from 'react';
+import { ExtraFormData } from '@superset-ui/core';
+import Popover from 'src/common/components/Popover';
+import Button from 'src/components/Button';
+import Icon from 'src/components/Icon';
+import {
+  CascadeFilterControl,
+  CascadeFilter,
+  FilterControl,
+} from './FilterBar';
+import { Filter } from './types';
+
+interface CascadePopoverProps {
+  filter: CascadeFilter;
+  visible: boolean;
+  onVisibleChange: (visible: boolean) => void;
+  onExtraFormDataChange: (filter: Filter, extraFormData: ExtraFormData) => void;
+}
+
+const CascadePopover: React.FC<CascadePopoverProps> = ({
+  filter,
+  visible,
+  onVisibleChange,
+  onExtraFormDataChange,
+}) => {
+  const title = <span>Select Parent Filters (ilosc poziomow) {filter.id}</span>;
+
+  const content = (
+    <CascadeFilterControl
+      data-test="cascade-filters-control"
+      key={filter.id}
+      filter={filter}
+      onExtraFormDataChange={onExtraFormDataChange}
+    />
+  );
+
+  return (
+    <>
+      {filter.cascadeChildren.length !== 0 && (
+        <>
+          <Button buttonSize="xs" onClick={() => onVisibleChange(true)}>
+            ({filter.cascadeChildren.length})
+            <Icon name="filter" />
+          </Button>
+
+          <Popover
+            content={content}
+            title={title}
+            trigger="click"
+            visible={visible}
+            onVisibleChange={onVisibleChange}
+            placement="right"
+            id={filter.id}
+          />
+        </>
+      )}
+      <FilterControl
+        filter={filter}
+        onExtraFormDataChange={onExtraFormDataChange}
+      />
+    </>
+  );
+};
+
+export default CascadePopover;

--- a/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
@@ -44,6 +44,10 @@ const StyledTitleBox = styled.div`
   margin: -5px -16px; // to override default antd padding
   padding: ${({ theme }) => theme.gridUnit * 2}px
     ${({ theme }) => theme.gridUnit * 4}px;
+
+  & > *:last-child {
+    cursor: pointer;
+  }
 `;
 
 const StyledTitle = styled.h4`
@@ -66,27 +70,35 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
   onVisibleChange,
   onExtraFormDataChange,
 }) => {
-  const getActiveChildren = useCallback(
-    (filter: CascadeFilter): CascadeFilter[] | null => {
-      const children = filter.cascadeChildren || [];
-      const currentValue = filter.currentValue || [];
+  const getActiveChildren = useCallback((filter: CascadeFilter):
+    | CascadeFilter[]
+    | null => {
+    const children = filter.cascadeChildren || [];
+    const currentValue = filter.currentValue || [];
 
-      const activeChildren = children.flatMap(
-        childFilter => getActiveChildren(childFilter) || [],
-      );
+    const activeChildren = children.flatMap(
+      childFilter => getActiveChildren(childFilter) || [],
+    );
 
-      if (activeChildren.length > 0) {
-        return activeChildren;
-      }
+    if (activeChildren.length > 0) {
+      return activeChildren;
+    }
 
-      if (currentValue.length > 0) {
-        return [filter];
-      }
+    if (currentValue.length > 0) {
+      return [filter];
+    }
 
-      return null;
-    },
-    [filter],
-  );
+    return null;
+  }, []);
+
+  if (!filter.cascadeChildren?.length) {
+    return (
+      <FilterControl
+        filter={filter}
+        onExtraFormDataChange={onExtraFormDataChange}
+      />
+    );
+  }
 
   const countFilters = (filter: CascadeFilter): number => {
     let count = 1;
@@ -122,35 +134,35 @@ const CascadePopover: React.FC<CascadePopoverProps> = ({
   const activeFilters = getActiveChildren(filter) || [filter];
 
   return (
-    <>
-      {activeFilters.map(activeFilter => (
-        <FilterControl
-          key={activeFilter.id}
-          filter={activeFilter}
-          onExtraFormDataChange={onExtraFormDataChange}
-          icon={
-            <>
-              {filter.cascadeChildren.length !== 0 && (
-                <Popover
-                  content={content}
-                  title={title}
-                  trigger="click"
-                  visible={visible}
-                  onVisibleChange={onVisibleChange}
-                  placement="rightBottom"
-                  id={filter.id}
-                  overlayStyle={{ minWidth: '400px' }}
-                >
+    <Popover
+      content={content}
+      title={title}
+      trigger="click"
+      visible={visible}
+      onVisibleChange={onVisibleChange}
+      placement="rightTop"
+      id={filter.id}
+      overlayStyle={{ minWidth: '400px' }}
+    >
+      <div>
+        {activeFilters.map(activeFilter => (
+          <FilterControl
+            key={activeFilter.id}
+            filter={activeFilter}
+            onExtraFormDataChange={onExtraFormDataChange}
+            icon={
+              <>
+                {filter.cascadeChildren.length !== 0 && (
                   <Pill onClick={() => onVisibleChange(true)}>
                     <Icon name="filter" /> {totalChildren}
                   </Pill>
-                </Popover>
-              )}
-            </>
-          }
-        />
-      ))}
-    </>
+                )}
+              </>
+            }
+          />
+        ))}
+      </div>
+    </Popover>
   );
 };
 

--- a/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/CascadePopover.tsx
@@ -21,12 +21,8 @@ import { ExtraFormData, styled, t } from '@superset-ui/core';
 import Popover from 'src/common/components/Popover';
 import Icon from 'src/components/Icon';
 import { Pill } from 'src/dashboard/components/FiltersBadge/Styles';
-import {
-  CascadeFilterControl,
-  CascadeFilter,
-  FilterControl,
-} from './FilterBar';
-import { Filter } from './types';
+import { CascadeFilterControl, FilterControl } from './FilterBar';
+import { Filter, CascadeFilter } from './types';
 
 interface CascadePopoverProps {
   filter: CascadeFilter;

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -150,8 +150,30 @@ const FilterControls = styled.div`
   padding: ${({ theme }) => theme.gridUnit * 4}px;
 `;
 
+const StyledCascadeChildrenList = styled.ul`
+  list-style-type: none;
+  & > * {
+    list-style-type: none;
+  }
+`;
+
+const StyledFilterControlTitle = styled.h4`
+  font-size: ${({ theme }) => theme.typography.sizes.l};
+  color: ${({ theme }) => theme.colors.grayscale.dark1};
+  text-transform: uppercase;
+`;
+
+const StyledFilterControlTitleBox = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: ${({ theme }) => theme.gridUnit * 2}px;
+`;
+
 interface FilterProps {
   filter: Filter;
+  icon?: React.ReactElement;
   onExtraFormDataChange: (filter: Filter, extraFormData: ExtraFormData) => void;
 }
 
@@ -178,8 +200,6 @@ const FilterValue: React.FC<FilterProps> = ({
   const [target] = targets;
   const { datasetId = 18, column } = target;
   const { name: groupby } = column;
-
-  console.log("Filter name: ", filter.name, "value", currentValue);
 
   const getFormData = (): Partial<QueryFormData> => ({
     adhoc_filters: [],
@@ -239,17 +259,21 @@ const FilterValue: React.FC<FilterProps> = ({
 
 export const FilterControl: React.FC<FilterProps> = ({
   filter,
+  icon,
   onExtraFormDataChange,
 }) => {
   const { name = '<undefined>' } = filter;
   return (
-    <div>
-      <h3>{name}</h3>
+    <>
+      <StyledFilterControlTitleBox>
+        <StyledFilterControlTitle>{name}</StyledFilterControlTitle>
+        <div>{icon}</div>
+      </StyledFilterControlTitleBox>
       <FilterValue
         filter={filter}
         onExtraFormDataChange={onExtraFormDataChange}
       />
-    </div>
+    </>
   );
 };
 
@@ -272,7 +296,7 @@ export const CascadeFilterControl: React.FC<CascadeFilterControlProps> = ({
         filter={filter}
         onExtraFormDataChange={onExtraFormDataChange}
       />
-      <ul>
+      <StyledCascadeChildrenList>
         {filter.cascadeChildren?.map(childFilter => (
           <li>
             <CascadeFilterControl
@@ -281,7 +305,7 @@ export const CascadeFilterControl: React.FC<CascadeFilterControlProps> = ({
             />
           </li>
         ))}
-      </ul>
+      </StyledCascadeChildrenList>
     </div>
   );
 };

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -158,8 +158,9 @@ const StyledCascadeChildrenList = styled.ul`
 `;
 
 const StyledFilterControlTitle = styled.h4`
-  font-size: ${({ theme }) => theme.typography.sizes.l};
+  font-size: ${({ theme }) => theme.typography.sizes.m}px;
   color: ${({ theme }) => theme.colors.grayscale.dark1};
+  margin: 0;
   text-transform: uppercase;
 `;
 
@@ -330,29 +331,6 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     }
   }, [filterConfigs]);
 
-  const handleExtraFormDataChange = (
-    filter: Filter,
-    extraFormData: ExtraFormData,
-  ) => {
-    setFilterData(prevFilterData => ({
-      ...prevFilterData,
-      [filter.id]: extraFormData,
-    }));
-
-    if (filter.isInstant) {
-      setExtraFormData(filter.id, extraFormData);
-    }
-  };
-
-  const handleApply = () => {
-    const filterIds = Object.keys(filterData);
-    filterIds.forEach(filterId => {
-      if (filterData[filterId]) {
-        setExtraFormData(filterId, filterData[filterId]);
-      }
-    });
-  };
-
   const cascadeFilters = useMemo((): CascadeFilter[] => {
     const getFilterValue = (filterId: string): string[] | null => {
       const filters = filterData[filterId]?.append_form_data?.filters;
@@ -386,6 +364,31 @@ const FilterBar: React.FC<FiltersBarProps> = ({
       .filter(filter => !filter.cascadeParentIds?.length)
       .map(getCascadeFilter);
   }, [filterConfigs, filterData]);
+
+  const handleExtraFormDataChange = (
+    filter: Filter,
+    extraFormData: ExtraFormData,
+  ) => {
+    setFilterData(prevFilterData => ({
+      ...prevFilterData,
+      [filter.id]: extraFormData,
+    }));
+
+    const children =
+      cascadeFilters.find(({ id }) => id === filter.id)?.cascadeChildren || [];
+    if (filter.isInstant || children.length > 0) {
+      setExtraFormData(filter.id, extraFormData);
+    }
+  };
+
+  const handleApply = () => {
+    const filterIds = Object.keys(filterData);
+    filterIds.forEach(filterId => {
+      if (filterData[filterId]) {
+        setExtraFormData(filterId, filterData[filterId]);
+      }
+    });
+  };
 
   return (
     <BarWrapper data-test="filter-bar" className={cx({ open: filtersOpen })}>

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -40,6 +40,7 @@ import {
 import { Filter } from './types';
 import { getChartDataRequest } from '../../../chart/chartAction';
 import { areObjectsEqual } from '../../../reduxUtils';
+import CascadePopover from './CascadePopover';
 
 const barWidth = `250px`;
 
@@ -227,7 +228,7 @@ const FilterValue: React.FC<FilterProps> = ({
   );
 };
 
-const FilterControl: React.FC<FilterProps> = ({
+export const FilterControl: React.FC<FilterProps> = ({
   filter,
   onExtraFormDataChange,
 }) => {
@@ -243,7 +244,7 @@ const FilterControl: React.FC<FilterProps> = ({
   );
 };
 
-interface CascadeFilter extends Filter {
+export interface CascadeFilter extends Filter {
   cascadeChildren: CascadeFilter[];
 }
 
@@ -252,7 +253,7 @@ interface CascadeFilterControlProps {
   onExtraFormDataChange: (filter: Filter, extraFormData: ExtraFormData) => void;
 }
 
-const CascadeFilterControl: React.FC<CascadeFilterControlProps> = ({
+export const CascadeFilterControl: React.FC<CascadeFilterControlProps> = ({
   filter,
   onExtraFormDataChange,
 }) => {
@@ -288,6 +289,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
   const canEdit = useSelector<any, boolean>(
     ({ dashboardInfo }) => dashboardInfo.dash_edit_perm,
   );
+  const [visiblePopoverId, setVisiblePopoverId] = useState<string | null>(null);
 
   useEffect(() => {
     if (filterConfigs.length === 0 && filtersOpen) {
@@ -381,9 +383,13 @@ const FilterBar: React.FC<FiltersBarProps> = ({
         </ActionButtons>
         <FilterControls>
           {cascadeFilters.map(filter => (
-            <CascadeFilterControl
-              data-test="filters-control"
+            <CascadePopover
+              data-test="cascade-filters-control"
               key={filter.id}
+              visible={visiblePopoverId === filter.id}
+              onVisibleChange={visible =>
+                setVisiblePopoverId(visible ? filter.id : null)
+              }
               filter={filter}
               onExtraFormDataChange={handleExtraFormDataChange}
             />

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigForm.tsx
@@ -103,6 +103,11 @@ export const FilterConfigForm: React.FC<FilterConfigFormProps> = ({
     );
   }
 
+  const parentFilterOptions = parentFilters.map(filter => ({
+    value: filter.id,
+    label: filter.title,
+  }));
+
   return (
     <>
       <Form.Item
@@ -154,13 +159,11 @@ export const FilterConfigForm: React.FC<FilterConfigFormProps> = ({
       <Form.Item
         name={['filters', filterId, 'parentFilter']}
         label={t('Parent Filter')}
+        initialValue={parentFilterOptions.find(
+          ({ value }) => value === filterToEdit?.cascadeParentIds[0],
+        )}
       >
-        <Select
-          options={parentFilters.map(filter => ({
-            value: filter.id,
-            label: filter.title,
-          }))}
-        />
+        <Select options={parentFilterOptions} isClearable />
       </Form.Item>
       <Form.Item
         name={['filters', filterId, 'isInstant']}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigForm.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigForm.tsx
@@ -30,6 +30,7 @@ import {
   Radio,
   Typography,
 } from 'src/common/components';
+import { Select } from 'src/components/Select/SupersetStyledSelect';
 import { Filter, NativeFiltersForm, Scope, Scoping } from './types';
 import ScopingTree from './ScopingTree';
 import { ColumnSelect } from './ColumnSelect';
@@ -65,6 +66,7 @@ export interface FilterConfigFormProps {
   removed?: boolean;
   restore: (filterId: string) => void;
   form: FormInstance<NativeFiltersForm>;
+  parentFilters: { id: string; title: string }[];
 }
 
 /**
@@ -77,6 +79,7 @@ export const FilterConfigForm: React.FC<FilterConfigFormProps> = ({
   removed,
   restore,
   form,
+  parentFilters,
 }) => {
   const [advancedScopingOpen, setAdvancedScopingOpen] = useState<Scoping>(
     Scoping.all,
@@ -147,6 +150,17 @@ export const FilterConfigForm: React.FC<FilterConfigFormProps> = ({
         initialValue={filterToEdit?.defaultValue}
       >
         <Input />
+      </Form.Item>
+      <Form.Item
+        name={['filters', filterId, 'parentFilter']}
+        label={t('Parent Filter')}
+      >
+        <Select
+          options={parentFilters.map(filter => ({
+            value: filter.id,
+            label: filter.title,
+          }))}
+        />
       </Form.Item>
       <Form.Item
         name={['filters', filterId, 'isInstant']}

--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -27,7 +27,6 @@ import { StyledModal } from 'src/common/components/Modal';
 import { LineEditableTabs } from 'src/common/components/Tabs';
 import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
 import { usePrevious } from 'src/common/hooks/usePrevious';
-import ErrorBoundary from 'src/components/ErrorBoundary';
 import { useFilterConfigMap, useFilterConfiguration } from './state';
 import FilterConfigForm from './FilterConfigForm';
 import { FilterConfiguration, NativeFiltersForm } from './types';
@@ -251,6 +250,15 @@ export function FilterConfigModal({
     );
   }
 
+  function getParentFilters(id: string) {
+    return filterIds
+      .filter(filterId => filterId !== id && !removedFilters[filterId])
+      .map(id => ({
+        id,
+        title: getFilterTitle(id),
+      }));
+  }
+
   const validateForm = useCallback(async () => {
     try {
       return (await form.validateFields()) as NativeFiltersForm;
@@ -289,7 +297,6 @@ export function FilterConfigModal({
         if (!formInputs) return filterConfigMap[id];
         return {
           id,
-          cascadeParentIds: [],
           name: formInputs.name,
           type: 'text',
           // for now there will only ever be one target
@@ -302,6 +309,9 @@ export function FilterConfigModal({
             },
           ],
           defaultValue: formInputs.defaultValue || null,
+          cascadeParentIds: formInputs.parentFilter
+            ? [formInputs.parentFilter.value]
+            : [],
           scope: {
             rootPath: [DASHBOARD_ROOT_ID],
             excluded: [],
@@ -388,6 +398,7 @@ export function FilterConfigModal({
                   filterToEdit={filterConfigMap[id]}
                   removed={!!removedFilters[id]}
                   restore={restoreFilter}
+                  parentFilters={getParentFilters(id)}
                 />
               </LineEditableTabs.TabPane>
             ))}

--- a/superset-frontend/src/dashboard/components/nativeFilters/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/types.ts
@@ -34,6 +34,10 @@ interface NativeFiltersFormItem {
   };
   column: string;
   defaultValue: string;
+  parentFilter: {
+    value: string;
+    label: string;
+  };
   inverseSelection: boolean;
   isInstant: boolean;
   allowsMultipleValues: boolean;

--- a/superset-frontend/src/dashboard/components/nativeFilters/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/types.ts
@@ -78,6 +78,7 @@ export interface Filter {
   allowsMultipleValues: boolean;
   cascadeParentIds: string[];
   defaultValue: string | null;
+  currentValue?: string[] | null;
   inverseSelection: boolean;
   isInstant: boolean;
   isRequired: boolean;

--- a/superset-frontend/src/dashboard/components/nativeFilters/types.ts
+++ b/superset-frontend/src/dashboard/components/nativeFilters/types.ts
@@ -91,6 +91,10 @@ export interface Filter {
   targets: [Target];
 }
 
+export interface CascadeFilter extends Filter {
+  cascadeChildren: CascadeFilter[];
+}
+
 export type FilterConfiguration = Filter[];
 
 export type SelectedValues = string[] | null;


### PR DESCRIPTION
### SUMMARY
This PR includes popover with cascading filters. It is possible to add "parent filter" and its "children".
In the Filter Bar, user can see filter label that’s youngest in the hierarchy which has values selected.
Next to the filter, in the Filter Bar, user can see a pill with the total layers count in this cascading filter.
There is also a validation added that ensures there are no cyclical hierarchies.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before there was no cascading filter popover.

After:
![cascading_filters_after](https://user-images.githubusercontent.com/47450693/101942788-605c9b80-3bea-11eb-83bd-50664f68a83c.gif)

### TEST PLAN
Verify manually.
Go to Filter bar and create some filters - remember about choosing parent filter.
Then click on the pill in the Filter Bar to check if is correct.
See if changes on the dashboard are applied.
Please check if there is validation for no cyclical hierarchies.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

cc @villebro @rusackas 