### PR TITLE
chore: Add Error Boundary to Filter Config Modal

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterConfigModal.tsx
@@ -27,6 +27,7 @@ import { StyledModal } from 'src/common/components/Modal';
 import { LineEditableTabs } from 'src/common/components/Tabs';
 import { DASHBOARD_ROOT_ID } from 'src/dashboard/util/constants';
 import { usePrevious } from 'src/common/hooks/usePrevious';
+import ErrorBoundary from 'src/components/ErrorBoundary';
 import { useFilterConfigMap, useFilterConfiguration } from './state';
 import FilterConfigForm from './FilterConfigForm';
 import { FilterConfiguration, NativeFiltersForm } from './types';
@@ -398,63 +399,67 @@ export function FilterConfigModal({
       centered
       data-test="filter-modal"
     >
-      <StyledModalBody>
-        <StyledForm
-          form={form}
-          onValuesChange={(changes, values: NativeFiltersForm) => {
-            if (
-              changes.filters &&
-              Object.values(changes.filters).some(
-                (filter: any) => filter.name != null,
-              )
-            ) {
-              // we only need to set this if a name changed
-              setFormValues(values);
-            }
-          }}
-        >
-          <FilterTabs
-            tabPosition="left"
-            onChange={setCurrentFilterId}
-            activeKey={currentFilterId}
-            onEdit={onTabEdit}
+      <ErrorBoundary>
+        <StyledModalBody>
+          <StyledForm
+            form={form}
+            onValuesChange={(changes, values: NativeFiltersForm) => {
+              if (
+                changes.filters &&
+                Object.values(changes.filters).some(
+                  (filter: any) => filter.name != null,
+                )
+              ) {
+                // we only need to set this if a name changed
+                setFormValues(values);
+              }
+            }}
           >
-            {filterIds.map(id => (
-              <LineEditableTabs.TabPane
-                tab={
-                  <FilterTabTitle
-                    className={removedFilters[id] ? 'removed' : ''}
-                  >
-                    <div>
-                      {removedFilters[id] ? t('(Removed)') : getFilterTitle(id)}
-                    </div>
-                    {removedFilters[id] && (
-                      <a
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => restoreFilter(id)}
-                      >
-                        {t('Undo?')}
-                      </a>
-                    )}
-                  </FilterTabTitle>
-                }
-                key={id}
-                closeIcon={removedFilters[id] ? <></> : <DeleteFilled />}
-              >
-                <FilterConfigForm
-                  form={form}
-                  filterId={id}
-                  filterToEdit={filterConfigMap[id]}
-                  removed={!!removedFilters[id]}
-                  restore={restoreFilter}
-                  parentFilters={getParentFilters(id)}
-                />
-              </LineEditableTabs.TabPane>
-            ))}
-          </FilterTabs>
-        </StyledForm>
-      </StyledModalBody>
+            <FilterTabs
+              tabPosition="left"
+              onChange={setCurrentFilterId}
+              activeKey={currentFilterId}
+              onEdit={onTabEdit}
+            >
+              {filterIds.map(id => (
+                <LineEditableTabs.TabPane
+                  tab={
+                    <FilterTabTitle
+                      className={removedFilters[id] ? 'removed' : ''}
+                    >
+                      <div>
+                        {removedFilters[id]
+                          ? t('(Removed)')
+                          : getFilterTitle(id)}
+                      </div>
+                      {removedFilters[id] && (
+                        <a
+                          role="button"
+                          tabIndex={0}
+                          onClick={() => restoreFilter(id)}
+                        >
+                          {t('Undo?')}
+                        </a>
+                      )}
+                    </FilterTabTitle>
+                  }
+                  key={id}
+                  closeIcon={removedFilters[id] ? <></> : <DeleteFilled />}
+                >
+                  <FilterConfigForm
+                    form={form}
+                    filterId={id}
+                    filterToEdit={filterConfigMap[id]}
+                    removed={!!removedFilters[id]}
+                    restore={restoreFilter}
+                    parentFilters={getParentFilters(id)}
+                  />
+                </LineEditableTabs.TabPane>
+              ))}
+            </FilterTabs>
+          </StyledForm>
+        </StyledModalBody>
+      </ErrorBoundary>
     </StyledModal>
   );
 }


### PR DESCRIPTION
### SUMMARY
Add Error boundary to Filter Config Modal.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
![image](https://user-images.githubusercontent.com/47450693/102077735-105c1f80-3e0a-11eb-9b7a-c18596d78c7b.png)


### TEST PLAN
Verify manually.
Throw errors:
for Filter Config Modal, type `throw new Error("test")` i.e. in `FilterConfigForm.tsx`84 line

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @villebro 
