### PR TITLE
fix: Add Cache Wrapper helper to avoid dataset request duplication

### DIFF
--- a/superset-frontend/spec/javascripts/utils/cacheWrapper_spec.ts
+++ b/superset-frontend/spec/javascripts/utils/cacheWrapper_spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { cacheWrapper } from 'src/utils/cacheWrapper';
+
+describe('cacheWrapper', () => {
+  const fnResult = 'fnResult';
+  const fn = jest.fn<string, [number, number]>().mockReturnValue(fnResult);
+
+  let wrappedFn: (a: number, b: number) => string;
+
+  beforeEach(() => {
+    const cache = new Map<string, any>();
+    wrappedFn = cacheWrapper(fn, cache);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls fn with its arguments once when the key is not found', () => {
+    const returnedValue = wrappedFn(1, 2);
+
+    expect(returnedValue).toEqual(fnResult);
+    expect(fn).toBeCalledTimes(1);
+    expect(fn).toBeCalledWith(1, 2);
+  });
+
+  describe('subsequent calls', () => {
+    it('returns the correct value without fn being called multiple times', () => {
+      const returnedValue1 = wrappedFn(1, 2);
+      const returnedValue2 = wrappedFn(1, 2);
+
+      expect(returnedValue1).toEqual(fnResult);
+      expect(returnedValue2).toEqual(fnResult);
+      expect(fn).toBeCalledTimes(1);
+    });
+
+    it('fn is called multiple times for different arguments', () => {
+      wrappedFn(1, 2);
+      wrappedFn(1, 3);
+
+      expect(fn).toBeCalledTimes(2);
+    });
+  });
+
+  describe('with custom keyFn', () => {
+    let cache: Map<string, any>;
+
+    beforeEach(() => {
+      cache = new Map<string, any>();
+      wrappedFn = cacheWrapper(fn, cache, (...args) => `key-${args[0]}`);
+    });
+
+    it('saves fn result in cache under generated key', () => {
+      wrappedFn(1, 2);
+      expect(cache.get('key-1')).toEqual(fnResult);
+    });
+
+    it('subsequent calls with same generated key calls fn once, even if other arguments have changed', () => {
+      wrappedFn(1, 1);
+      wrappedFn(1, 2);
+      wrappedFn(1, 3);
+
+      expect(fn).toBeCalledTimes(1);
+    });
+  });
+});

--- a/superset-frontend/src/dashboard/components/nativeFilters/ColumnSelect.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/ColumnSelect.tsx
@@ -23,6 +23,7 @@ import { useChangeEffect } from 'src/common/hooks/useChangeEffect';
 import { AsyncSelect } from 'src/components/Select';
 import { useToasts } from 'src/messageToasts/enhancers/withToasts';
 import { getClientErrorObject } from 'src/utils/getClientErrorObject';
+import { cacheWrapper } from 'src/utils/cacheWrapper';
 import { NativeFiltersForm } from './types';
 
 type ColumnSelectValue = {
@@ -37,6 +38,14 @@ interface ColumnSelectProps {
   value?: ColumnSelectValue | null;
   onChange?: (value: ColumnSelectValue | null) => void;
 }
+
+const localCache = new Map<string, any>();
+
+const cachedSupersetGet = cacheWrapper(
+  SupersetClient.get,
+  localCache,
+  ({ endpoint }) => endpoint || '',
+);
 
 /** Special purpose AsyncSelect that selects a column from a dataset */
 // eslint-disable-next-line import/prefer-default-export
@@ -61,7 +70,7 @@ export function ColumnSelect({
 
   function loadOptions() {
     if (datasetId == null) return [];
-    return SupersetClient.get({
+    return cachedSupersetGet({
       endpoint: `/api/v1/dataset/${datasetId}`,
     }).then(
       ({ json: { result } }) => {

--- a/superset-frontend/src/utils/cacheWrapper.ts
+++ b/superset-frontend/src/utils/cacheWrapper.ts
@@ -1,0 +1,15 @@
+export const cacheWrapper = <T extends Array<any>, U>(
+  fn: (...args: T) => U,
+  cache: Map<string, any>,
+  keyFn: (...args: T) => string = (...args: T) => JSON.stringify([...args]),
+) => {
+  return (...args: T): U => {
+    const key = keyFn(...args);
+    if (cache.has(key)) {
+      return cache.get(key);
+    }
+    const result = fn(...args);
+    cache.set(key, result);
+    return result;
+  };
+};

--- a/superset-frontend/src/utils/cacheWrapper.ts
+++ b/superset-frontend/src/utils/cacheWrapper.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 export const cacheWrapper = <T extends Array<any>, U>(
   fn: (...args: T) => U,
   cache: Map<string, any>,


### PR DESCRIPTION
### SUMMARY
The problem was that datasource and field are requested from API every time (instead of keeping them cached when they have been fetched once). The aim of the PR was to limit the API requests using Cache Wrapper helper.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![dedupe_before](https://user-images.githubusercontent.com/47450693/102382981-4dbbdb00-3fcb-11eb-9711-6018c58f94c9.gif)

After:
![dedupe_after_correct](https://user-images.githubusercontent.com/47450693/102382972-4a285400-3fcb-11eb-852f-3f969df00d8b.gif)

### TEST PLAN
Verify manually. 
Create new filter or edit existing one. 
Choose datasource and field and check the network if it works the same as presented on the gif.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

cc @villebro 