### PR TITLE
fix: Toggling Filter Bar

### DIFF
--- a/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
+++ b/superset-frontend/src/dashboard/components/nativeFilters/FilterBar.tsx
@@ -397,7 +397,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
     <BarWrapper data-test="filter-bar" className={cx({ open: filtersOpen })}>
       <CollapsedBar
         className={cx({ open: !filtersOpen })}
-        onClick={toggleFiltersBar}
+        onClick={() => toggleFiltersBar(true)}
       >
         <Icon name="filter" />
         <Icon name="collapse" />
@@ -414,7 +414,7 @@ const FilterBar: React.FC<FiltersBarProps> = ({
               <Icon name="edit" data-test="create-filter" />
             </FilterConfigurationLink>
           )}
-          <Icon name="expand" onClick={toggleFiltersBar} />
+          <Icon name="expand" onClick={() => toggleFiltersBar(false)} />
         </TitleArea>
         <ActionButtons>
           <Button buttonStyle="secondary" buttonSize="sm">


### PR DESCRIPTION
### SUMMARY
There was a problem with toggling the Filter Bar. It was not possible to hide the Filter Bar.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
before:
![toggle_before](https://user-images.githubusercontent.com/47450693/102496754-1a835580-4078-11eb-8441-46ff77c8d283.gif)

after:
![toggle_after](https://user-images.githubusercontent.com/47450693/102496770-1fe0a000-4078-11eb-8119-8998d17a6897.gif)

### TEST PLAN
Go to the Dashboard and try clicking "Expand" and "Collapse" icons located in the Filter Bar.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
